### PR TITLE
Fix a bug that causes unexpected core dump

### DIFF
--- a/src/front/grammar_analyze.cpp
+++ b/src/front/grammar_analyze.cpp
@@ -84,7 +84,6 @@ static void initToken(const char c, Dfstate& state, std::vector<Token>& res) {
     Token token;
     if (c == 'i') {
         state = Dfstate::INT_I;
-        token.type = ID_TYPE;
     } else if (isAlpha(c) || c == '_') {
         state = Dfstate::ID;
         token.type = ID_TYPE;
@@ -122,9 +121,10 @@ static void handleState(const char c, Dfstate& state, std::vector<Token>& res) {
                 res.back().val += c;
             } else {
                 state = Dfstate::ID;
-                if (isAlpha(c) || isDigital(c) || c == '_')
+                if (isAlpha(c) || isDigital(c) || c == '_') {
                     res.back().val += c;
-                else {
+                    res.back().type = ID_TYPE;
+                } else {
                     state = Dfstate::INITIAL;
                     initToken(c, state, res);
                 }
@@ -134,11 +134,13 @@ static void handleState(const char c, Dfstate& state, std::vector<Token>& res) {
             if (c == 't') {
                 state = Dfstate::INT;
                 res.back().val += c;
+                res.back().type = INT_TYPE;
             } else {
                 state = Dfstate::ID;
-                if (isAlpha(c) || isDigital(c) || c == '_')
+                if (isAlpha(c) || isDigital(c) || c == '_') {
                     res.back().val += c;
-                else {
+                    res.back().type = ID_TYPE;
+                } else {
                     state = Dfstate::INITIAL;
                     initToken(c, state, res);
                 }
@@ -146,12 +148,12 @@ static void handleState(const char c, Dfstate& state, std::vector<Token>& res) {
             break;
         case Dfstate::INT:
             if (isBlank(c)) {
-                res.back().type = INT_TYPE;
                 state = Dfstate::INITIAL;
                 initToken(c, state, res);
             } else {
                 state = Dfstate::ID;
                 res.back().val += c;
+                res.back().type = ID_TYPE;
             }
             break;
         case Dfstate::ID:

--- a/src/front/syntax_analyze.cpp
+++ b/src/front/syntax_analyze.cpp
@@ -127,6 +127,8 @@ SimpleASTNode::Ptr SimpleSyntaxAnalyzer::intDelare(TokenReader& tokens)
     if (!token.isEmpty() && token.type == INT_TYPE) {
         token = tokens.read(); //consume key word "int"
         node = SimpleASTNode::create(ASTNodeType::INT_DECLARATION, token.val);
+        if (tokens.empty())
+            throw std::invalid_argument("variable name expected!");
         while (!tokens.empty()) {
             if (tokens.peek().type == ID_TYPE) {
                 token = tokens.read(); //consume id

--- a/test/syntax-test.cpp
+++ b/test/syntax-test.cpp
@@ -8,27 +8,26 @@
 int main(int, char**) {
     std::vector<Token> res = {};
 
-    std::string str1 = "int age = 40";
+    std::vector<std::string> testCases = {"int age = 40", "int arg, b = 23, a=3,c", "int a = 2 + 3 *5 + 8 + 9 *100", \
+    "int a = 2 + 3 +5", "int", "int "};
 
-    std::string str4 = "int arg, b = 23, a=3,c";
+    for (auto& item : testCases) {
+        grammar_analyze(item, res);
+        for (std::vector<Token>::iterator iter = res.begin(); iter != res.end(); iter++)
+            std::cout << type2str(iter->type) << ": " << iter->val << std::endl;
+        SimpleASTNode::Ptr node;
+        TokenReader reader(res);
+        try {
+            node = SimpleSyntaxAnalyzer::instance()->intDelare(reader);
+        } catch (std::exception& e) {
+            std::cout << e.what() << std::endl;
+            std::terminate();
+        }
 
-    std::string str2 = "int a = 2 + 3 *5 + 8 + 9 *100";
-    std::string str5 = "int a = 2 + 3 +5";
-
-    grammar_analyze(str5, res);
-    SimpleASTNode::Ptr node;
-    TokenReader reader(res);
-    try {
-        node = SimpleSyntaxAnalyzer::instance()->intDelare(reader);
-    } catch (std::exception& e) {
-        std::cout << e.what() << std::endl;
-        std::terminate();
+        if (node != nullptr)
+            node->print(0);
+        res.erase(res.begin(), res.end());
+        std::cout << (reader.empty() ? "TokenReader is empty\n" : "TokenReader still has items\n") << std::endl;
     }
-
-    for (std::vector<Token>::iterator iter = res.begin(); iter != res.end(); iter++)
-        std::cout << type2str(iter->type) << ": " << iter->val << std::endl;
-
-    node->print(0);
-    std::cout << (reader.empty() ? "TokenReader is empty" : "TokenReader still has items") << std::endl;
     return 0;
 }


### PR DESCRIPTION
1. Refine syntax-test code to meet multi static test cases
2. Add only "int " and "int" cases.
(1). "int "
This case will be handled incorrectly.
The test output is:

    Int: int

    Int Key Word : int
    TokenReader is empty

Expected results: throw an exception then trigger a core dump.
Root cause: No throw exception if no token after "int" key word.

(2). "int"
This case will result in unexpected core dump.
The test output is:

    Identifier: int

    Segmentation fault (core dumped)

Obviously, there exist 2 bugs:
a. "int" is "Int" not "Identifier"
b. core dump.

Root cause:
a. This mainly because the wrong handler of the "INT" token.
b. There are 2 bugs in the program:
    *. There is no check of node in syntax test program.
    *. Wrong handling in this situation in syntax handle.

Signed-off-by: Zhang, Shouheng <zhangshouhengdtc@163.com>